### PR TITLE
tGameOptionInit

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -266,6 +266,74 @@ sReason:
 Description.
 ```
 
+### tGameOptionInit
+
+nOptionNo:
+```bash
+Unique identification number for the GameOption.
+```
+
+sys_create_date:
+```bash
+The timestamp of creation. (not supposedto be changed)
+```
+
+sys_update_date:
+```bash
+The timestamp of the last update. (not supposedto be changed)
+```
+
+nDefaultValue:
+```bash
+Enable or Disable given option on default character options.
+
+0 = Disabled.
+1 = Enabled.
+```
+
+blsActive:
+```bash
+TBD.
+```
+
+sDescription:
+```bash
+Description of optionname.
+```
+A quick Overview nOption on sDescription:
+
+|nOptionNo  | sDescription          |
+|:---------:|:----------------------|
+|0          |My Character Name      |
+|1          |Other Character Names  |
+|2          |NPC Name               |
+|3          |Monster Name           |
+|4          |Drop Item Name         |
+|5          |My Character HP        |
+|6          |My Character SP(LP)    |
+|7          |Interface              |
+|8          |Chat Balloon           |
+|9          |Name Tag Change        |
+|10         |Tool Tip Pop Up        |
+|11         |Play Guide             |
+|12         |Whisper                |
+|13         |Trade Request          |
+|14         |Party Invite           |
+|15         |Guild Invite           |
+|16         |System Message         |
+|17         |Confirmations          |
+|18         |unknown                |
+|19         |Hide Chat Box          |
+|20         |unknown                |
+|21         |unknown                |
+|22         |Command Prompt         |
+|23         |unknown                |
+|24         |unknown                |
+|25         |unknown                |
+|26         |unknown                |
+|27         |Inventory Autostack    |
+
+
 ## Options Database
 
 ### Auto_Account_Creation

--- a/docs/database.md
+++ b/docs/database.md
@@ -275,12 +275,12 @@ Unique identification number for the GameOption.
 
 sys_create_date:
 ```bash
-The timestamp of creation. (not supposedto be changed)
+The timestamp of creation. (not supposed to be changed)
 ```
 
 sys_update_date:
 ```bash
-The timestamp of the last update. (not supposedto be changed)
+The timestamp of the last update. (not supposed to be changed)
 ```
 
 nDefaultValue:


### PR DESCRIPTION
As requested the documentation gets an extension for World00_Character Databese on tGameoptionInit.

Included are:

- basic Tabledescription
- map on nOptionNo and sDescription

Please let me know if something has to be changed.